### PR TITLE
fhemduino_pt2262 - minor update on attributeslist (missing space)

### DIFF
--- a/14_FHEMduino_PT2262.pm
+++ b/14_FHEMduino_PT2262.pm
@@ -44,7 +44,7 @@ sub FHEMduino_PT2262_Initialize($){ ############################################
   $hash->{UndefFn}   = "FHEMduino_PT2262_Undef";
   $hash->{AttrFn}    = "FHEMduino_PT2262_Attr";
   $hash->{ParseFn}   = "FHEMduino_PT2262_Parse";
-  $hash->{AttrList}  = "IODev ITrepetition do_not_notify:0,1 showtime:0,1 ignore:0,1 model:itremote,itswitch,itdimmer".
+  $hash->{AttrList}  = "IODev ITrepetition do_not_notify:0,1 showtime:0,1 ignore:0,1 model:itremote,itswitch,itdimmer ".
   $readingFnAttributes;
 }
 


### PR DESCRIPTION
$readingFnAttributes was not separated from attribute before